### PR TITLE
Изменено возращаемое значение метода insertNode()

### DIFF
--- a/binaryTree/src/main/kotlin/org/tree/binaryTree/TemplateBSTree.kt
+++ b/binaryTree/src/main/kotlin/org/tree/binaryTree/TemplateBSTree.kt
@@ -8,7 +8,7 @@ abstract class TemplateBSTree<T : Comparable<T>, NODE_T : TemplateNode<T, NODE_T
         if (curNode == null) {
             if (root === curNode) {
                 root = newNode
-                return newNode
+                return null
             } else {
                 throw IllegalArgumentException("Received a non-root null node")
             }
@@ -16,17 +16,17 @@ abstract class TemplateBSTree<T : Comparable<T>, NODE_T : TemplateNode<T, NODE_T
             if (newNode.elem < curNode.elem) {
                 if (curNode.left == null) {
                     curNode.left = newNode
+                    return curNode
                 } else {
-                    insertNode(curNode.left, newNode)
+                    return insertNode(curNode.left, newNode)
                 }
-                return curNode.left
             } else if (newNode.elem > curNode.elem) {
                 if (curNode.right == null) {
                     curNode.right = newNode
+                    return curNode
                 } else {
-                    insertNode(curNode.right, newNode)
+                    return insertNode(curNode.right, newNode)
                 }
-                return curNode.right
             } else {
                 return null // STTK: 10%
             }

--- a/binaryTree/src/main/kotlin/org/tree/binaryTree/TemplateBalanceBSTree.kt
+++ b/binaryTree/src/main/kotlin/org/tree/binaryTree/TemplateBalanceBSTree.kt
@@ -29,7 +29,7 @@ abstract class TemplateBalanceBSTree<T : Comparable<T>, NODE_T : TemplateNode<T,
     override fun insertNode(curNode: NODE_T?, newNode: NODE_T): NODE_T? {
         val insNode = super.insertNode(curNode, newNode)
         if (curNode != null) { // STTK: maybe if cur_node = root, and root = null
-            if ((curNode.left === insNode) or (curNode.right === insNode)) {
+            if (curNode === insNode) {
                 balance(curNode, BalanceCase.OpType.INSERT, BalanceCase.Recursive.END)
             } else {
                 balance(curNode, BalanceCase.OpType.INSERT, BalanceCase.Recursive.RECURSIVE_CALL)


### PR DESCRIPTION
Значение, которое возвращает метод `insertNode()`, было изменено с `ссылки на вставленную ноду` на `ссылку на родителя вставленной ноды`. Это сделано для более простой и удобной реализации красночерного дерева.