### PR TITLE
Изменено возращаемое значение traversal()

### DIFF
--- a/binaryTree/src/main/kotlin/org/tree/binaryTree/TemplateBSTree.kt
+++ b/binaryTree/src/main/kotlin/org/tree/binaryTree/TemplateBSTree.kt
@@ -134,7 +134,7 @@ abstract class TemplateBSTree<T : Comparable<T>, NODE_T : TemplateNode<T, NODE_T
         }
     }
 
-    fun traversal(order: TemplateNode.Traversal): MutableList<T>? {
-        return root?.traversal(order)
+    fun traversal(order: TemplateNode.Traversal): MutableList<T> {
+        return root?.traversal(order) ?: mutableListOf()
     }
 }


### PR DESCRIPTION
Раньше метод `traversal` возвращал `null` при нулевом пустом дереве, теперь возвращает пустой список.