### PR TITLE
Добавлено сохранение АВЛ дерева

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -4,12 +4,14 @@
 
 plugins {
     id("org.tree.kotlin-application-conventions")
+    kotlin("plugin.serialization") version "1.8.20"
 }
 
 dependencies {
     implementation(project(":binaryTree"))
 
     implementation("org.neo4j.driver", "neo4j-java-driver", "5.7.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.0")
 }
 
 application {

--- a/app/src/main/kotlin/org/tree/app/controller/io/Json.kt
+++ b/app/src/main/kotlin/org/tree/app/controller/io/Json.kt
@@ -1,4 +1,21 @@
 package org.tree.app.controller.io
 
+import kotlinx.serialization.Serializable
+
+@Serializable
+private data class JsonAVLNode(
+    val key: Int,
+    val value: String?,
+    val x: Double,
+    val y: Double,
+    val height: Int,
+    val lkey: Int?,
+    val rkey: Int?
+)
+
+@Serializable
+private data class JsonAVLTree(
+    val AVLTree: Array<JsonAVLNode?>
+)
 class Json {
 }

--- a/app/src/main/kotlin/org/tree/app/controller/io/Json.kt
+++ b/app/src/main/kotlin/org/tree/app/controller/io/Json.kt
@@ -1,6 +1,16 @@
 package org.tree.app.controller.io
 
 import kotlinx.serialization.Serializable
+import kotlinx.serialization.decodeFromString
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import org.neo4j.driver.exceptions.value.Uncoercible
+import org.tree.app.view.NodeView
+import org.tree.binaryTree.AVLNode
+import org.tree.binaryTree.KVP
+import java.io.File
+import java.io.FileNotFoundException
+import java.io.IOException
 
 @Serializable
 private data class JsonAVLNode(
@@ -18,4 +28,47 @@ private data class JsonAVLTree(
     val AVLTree: Array<JsonAVLNode?>
 )
 class Json {
+    val dirPath = "json-saved"
+
+    fun exportAVLTree(root: NodeView<AVLNode<KVP<Int, String>>>) {
+        val sb = StringBuilder()
+        sb.append("{\"AVLTree\":[")
+        traverseExportAVLNode(sb, root)
+        sb.append("]}")
+        File(dirPath).mkdirs()
+        File(dirPath, "output.json").run {
+            createNewFile()
+            writeText(sb.toString())
+        }
+    }
+
+    private fun traverseExportAVLNode(
+        sb: StringBuilder,
+        nodeView: NodeView<AVLNode<KVP<Int, String>>>,
+    ) {
+
+        with(nodeView) {
+            val json = JsonAVLNode(
+                key = node.elem.key,
+                value = node.elem.v,
+                x = x,
+                y = y,
+                height = node.height,
+                lkey = l?.node?.elem?.key,
+                rkey = r?.node?.elem?.key
+            )
+
+            sb.append(Json.encodeToString(json))
+
+            l?.let {
+                sb.append(",")
+                traverseExportAVLNode(sb, it)
+            }
+            r?.let {
+                sb.append(",")
+                traverseExportAVLNode(sb, it)
+            }
+        }
+
+    }
 }

--- a/app/src/main/kotlin/org/tree/app/controller/io/Json.kt
+++ b/app/src/main/kotlin/org/tree/app/controller/io/Json.kt
@@ -1,0 +1,4 @@
+package org.tree.app.controller.io
+
+class Json {
+}

--- a/app/src/main/kotlin/org/tree/app/controller/io/Json.kt
+++ b/app/src/main/kotlin/org/tree/app/controller/io/Json.kt
@@ -69,6 +69,74 @@ class Json {
                 traverseExportAVLNode(sb, it)
             }
         }
+    }
 
+    fun importAVLTree(fileName: String): NodeView<AVLNode<KVP<Int, String>>>? {  // when we have treeView, fun will be rewritten
+        val json = try {
+            File(dirPath, fileName).readText()
+        } catch (_: FileNotFoundException) {
+            return null
+        }
+
+        val jsonTree = Json.decodeFromString<JsonAVLTree>(json)
+        return parseAVLNodes(jsonTree)
+    }
+
+    private class NodeAndKeys(
+        val nv: NodeView<AVLNode<KVP<Int, String>>>,
+        val lkey: Int?,
+        val rkey: Int?
+    )
+
+    private fun parseAVLNodes(nodeAndKeysRecords: JsonAVLTree): NodeView<AVLNode<KVP<Int, String>>>? {
+        val key2nk = mutableMapOf<Int, NodeAndKeys>()
+        for (nkRecord in nodeAndKeysRecords.AVLTree) {
+            try {
+                val key = nkRecord?.key ?: throw IOException("Invalid nodes label in the database")
+                val value = nkRecord.value
+                val nv = NodeView(AVLNode(KVP(key, value)))
+
+                nv.x = nkRecord.x
+                nv.y = nkRecord.y
+                nv.node.height = nkRecord.height
+
+                val lkey = nkRecord.lkey
+                val rkey = nkRecord.rkey
+                key2nk[key] = NodeAndKeys(nv, lkey, rkey)
+            } catch (ex: Uncoercible) {
+                throw IOException("Invalid nodes label in the database", ex)
+            }
+        }
+        val nks = key2nk.values.toTypedArray()
+        if (nks.isEmpty()) { // if nodeAndKeysRecords was empty
+            return null
+        }
+
+        for (nk in nks) {
+            nk.lkey?.let {
+                nk.nv.l = key2nk[it]?.nv
+                key2nk.remove(it)
+            }
+            nk.nv.l?.let {
+                nk.nv.node.left = it.node
+            }
+
+            nk.rkey?.let {
+                nk.nv.r = key2nk[it]?.nv
+                key2nk.remove(it)
+            }
+            nk.nv.r?.let {
+                nk.nv.node.right = it.node
+            }
+        }
+        if (key2nk.values.size != 1) {
+            throw IOException("Found ${key2nk.values.size} nodes without parents in database, expected only 1 node")
+        }
+        val root = key2nk.values.first().nv
+        return root
+    }
+
+    fun cleanDataBase(fileName: String) {
+        File(dirPath, "$fileName.json").delete()
     }
 }


### PR DESCRIPTION
 Сохраняем АВЛ дерево в JSON файл. Файлы записываются и читаются из папки json-saved, которая создается при сохранении дерева. Параллельно с созданием GUI нужно будет добавить нормальные названия файлам и поменять расположение json-saved.