### PR TITLE
Исправление ошибок, рефакторинг SQLiteIO 

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,8 +100,9 @@ At SQLite database we store BinSearchTree. There are 2 types of objects with the
 
 We have functions:
 
-- `exportTree(TreeController, file)` - writes information stored in TreeController object  to a `file`
-- `importTree(file)` - reads the tree stored in the `file` and returns TreeController object
+- `exportTree(TreeController, file)` - writes information stored in TreeController object  to a `file` in preorder order. 
+- `importTree(file)` - reads the tree stored in the `file` and returns TreeController object. **Nodes must be stored in preorder order (check root -> then check left child -> then check right child).**
+If there are some extra tree nodes, that can't fit in the tree, then `importTree` will throw `HandledIOException`. 
 
 
 ### Neo4j

--- a/app/src/main/kotlin/org/tree/app/controller/TreeController.kt
+++ b/app/src/main/kotlin/org/tree/app/controller/TreeController.kt
@@ -83,7 +83,7 @@ class TreeController<NODE_T : TemplateNode<KVP<Int, String>, NODE_T>>(
         return tree.find(obj)
     }
 
-    private fun getNodeCol(curNode: NODE_T): Color {
+    fun getNodeCol(curNode: NODE_T): Color {
         return if (curNode is RBNode<*>) {
             if (curNode.col == RBNode.Colour.BLACK) {
                 Color.DarkGray

--- a/app/src/main/kotlin/org/tree/app/controller/io/SQLiteIO.kt
+++ b/app/src/main/kotlin/org/tree/app/controller/io/SQLiteIO.kt
@@ -41,12 +41,12 @@ class SQLiteIO {
     private lateinit var treeController: TreeController<Node<KVP<Int, String>>>
     fun importTree(file: File): TreeController<Node<KVP<Int, String>>> {
         Database.connect("jdbc:sqlite:${file.path}", "org.sqlite.JDBC")
+        treeController = TreeController(BinSearchTree())
         try {
             transaction {
                 val setOfNodes = InstanceOfNode.all().toMutableSet()
                 val amountOfNodes = setOfNodes.count()
                 if (amountOfNodes > 0) {
-                    treeController = TreeController(BinSearchTree())
                     parseRootForImport(setOfNodes)
                 }
             }
@@ -63,6 +63,7 @@ class SQLiteIO {
             throw HandledIOException("Directory ${file.toPath().parent} cannot be created: no access", ex)
         }
         Database.connect("jdbc:sqlite:${file.path}", "org.sqlite.JDBC")
+        treeController = treeController_
         transaction {
             try {
                 SchemaUtils.drop(Nodes)
@@ -70,7 +71,6 @@ class SQLiteIO {
             } catch (ex: ExposedSQLException) {
                 throw HandledIOException("File is not a database", ex)
             }
-            treeController = treeController_
             val root = treeController.tree.root
             if (root != null) {
                 parseNodesForExport(root, null)

--- a/app/src/main/kotlin/org/tree/app/controller/io/SQLiteIO.kt
+++ b/app/src/main/kotlin/org/tree/app/controller/io/SQLiteIO.kt
@@ -45,7 +45,6 @@ class SQLiteIO {
         Database.connect("jdbc:sqlite:${file.path}", "org.sqlite.JDBC")
         try {
             transaction {
-                addLogger(StdOutSqlLogger)
                 val setOfNodes = InstanceOfNode.all().toMutableSet()
                 val amountOfNodes = setOfNodes.count()
                 if (amountOfNodes > 0) {
@@ -67,7 +66,6 @@ class SQLiteIO {
         }
         Database.connect("jdbc:sqlite:${file.path}", "org.sqlite.JDBC")
         transaction {
-            addLogger(StdOutSqlLogger)
             try {
                 SchemaUtils.drop(Nodes)
                 SchemaUtils.create(Nodes)

--- a/app/src/main/kotlin/org/tree/app/controller/io/SQLiteIO.kt
+++ b/app/src/main/kotlin/org/tree/app/controller/io/SQLiteIO.kt
@@ -11,6 +11,7 @@ import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.exceptions.ExposedSQLException
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.SchemaUtils
+import org.jetbrains.exposed.sql.exists
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.tree.binaryTree.KVP
 import org.tree.binaryTree.Node
@@ -44,10 +45,15 @@ class SQLiteIO {
         treeController = TreeController(BinSearchTree())
         try {
             transaction {
-                val setOfNodes = InstanceOfNode.all().toMutableSet()
-                val amountOfNodes = setOfNodes.count()
-                if (amountOfNodes > 0) {
-                    parseRootForImport(setOfNodes)
+                if (Nodes.exists()) {
+                    val setOfNodes = InstanceOfNode.all().toMutableSet()
+                    val amountOfNodes = setOfNodes.count()
+                    if (amountOfNodes > 0) {
+                        parseRootForImport(setOfNodes)
+                    }
+                }
+                else{
+                    throw HandledIOException("Database without a node table")
                 }
             }
         } catch (ex: ExposedSQLException) {

--- a/app/src/main/kotlin/org/tree/app/controller/io/SQLiteIO.kt
+++ b/app/src/main/kotlin/org/tree/app/controller/io/SQLiteIO.kt
@@ -3,6 +3,7 @@ package org.tree.app.controller.io
 import NodeExtension
 import TreeController
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.ui.graphics.Color
 import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.IntEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
@@ -171,6 +172,6 @@ class SQLiteIO {
         node: Node<KVP<Int, String>>,
         x: Int, y: Int
     ) {
-        treeController.nodes[node] = NodeExtension(mutableStateOf(x), mutableStateOf(y))
+        treeController.nodes[node] = NodeExtension(mutableStateOf(x), mutableStateOf(y), Color.Yellow)
     }
 }

--- a/app/src/main/kotlin/org/tree/app/controller/io/SQLiteIO.kt
+++ b/app/src/main/kotlin/org/tree/app/controller/io/SQLiteIO.kt
@@ -11,8 +11,6 @@ import org.jetbrains.exposed.dao.id.IntIdTable
 import org.jetbrains.exposed.exceptions.ExposedSQLException
 import org.jetbrains.exposed.sql.Database
 import org.jetbrains.exposed.sql.SchemaUtils
-import org.jetbrains.exposed.sql.StdOutSqlLogger
-import org.jetbrains.exposed.sql.addLogger
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.tree.binaryTree.KVP
 import org.tree.binaryTree.Node

--- a/app/src/main/kotlin/org/tree/app/controller/io/SQLiteIO.kt
+++ b/app/src/main/kotlin/org/tree/app/controller/io/SQLiteIO.kt
@@ -3,7 +3,6 @@ package org.tree.app.controller.io
 import NodeExtension
 import TreeController
 import androidx.compose.runtime.mutableStateOf
-import androidx.compose.ui.graphics.Color
 import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.IntEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
@@ -178,6 +177,6 @@ class SQLiteIO {
         node: Node<KVP<Int, String>>,
         x: Int, y: Int
     ) {
-        treeController.nodes[node] = NodeExtension(mutableStateOf(x), mutableStateOf(y), Color.Yellow)
+        treeController.nodes[node] = NodeExtension(mutableStateOf(x), mutableStateOf(y), treeController.getNodeCol(node))
     }
 }


### PR DESCRIPTION
- Теперь при обработке невалидной базы данных выдает сообщение об ошибке 
- Исправлена ошибка: при сохранении дерева не передаваося цвет узла бинарного дерева
- `IOException` заменен `HandledIOException`
- Изменен `readme`, добавлены некоторые пояснения
- Удален логгер
- При попытке чтения из базы данных без таблицы `Nodes` метод `importTree` ловит ошибку
- Корректная работа при импортировании из пустой таблицы `Nodes` 